### PR TITLE
Add class relationships for class diagram

### DIFF
--- a/docs/diagrams/CombinedCompatibleClassDiagram.puml
+++ b/docs/diagrams/CombinedCompatibleClassDiagram.puml
@@ -20,6 +20,10 @@ package "model.person" {
   class BloodTypeCompatibilityPredicate
 }
 
+CombinedCommand --> CombinedPredicate : uses
+CompatibleCommand --> BloodTypeCompatibilityPredicate : uses
+
+CombinedCommandParser --> CombinedCommand : creates
 
 @enduml
 


### PR DESCRIPTION
Closes #123.

Class diagram is missing some class dependencies.

It doesn't correctly represent the relationship between classes.

Let's add the relevant relationships to the class diagram.

The diagram will require more updates in the future.