### PR TITLE
Reformat names to basic whitespace

### DIFF
--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -27,6 +27,7 @@ public class Name {
      */
     public Name(String name) {
         requireNonNull(name);
+        name = name.replaceAll("\\s+", " "); // replaces all whitespaces with basic space character
         checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
         fullName = name;
     }


### PR DESCRIPTION
Closes #166.

Names with extra whitespaces are recognised as unique, eg. "John Doe" vs "John  Doe".

This can result in duplicate and invalid names.

Let's reduce all whitespaces to a single character before checking for duplicate names.

This also avoids tab and other special space characters.