### PR TITLE
Convert all bloodtypes to uppercase

### DIFF
--- a/src/main/java/seedu/address/model/person/BloodType.java
+++ b/src/main/java/seedu/address/model/person/BloodType.java
@@ -21,6 +21,7 @@ public class BloodType {
      */
     public BloodType(String bloodType) {
         requireNonNull(bloodType);
+        bloodType = bloodType.toUpperCase();
         checkArgument(isValidBloodType(bloodType), MESSAGE_CONSTRAINTS);
         this.bloodType = bloodType.toUpperCase();
     }


### PR DESCRIPTION
Closes #162.

The addressbook recognises and stores lowercase bloodtypes.

They do not appear during bloodtype searches as it is case sensitive.

Let's convert all bloodtypes to uppercase during entry to avoid the issue.

Existing lowercase bloodtypes in an addressbook will be udpated.