### PR TITLE
Fix priority error message

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -17,6 +17,8 @@ public class Messages {
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_NO_PERSONS_FOUND = "%s does not exist in directory";
+    public static final String MESSAGE_NO_PRIORITIES_FOUND =
+                "No recipients could be found for the following list of priorities: %s";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/seedu/address/logic/commands/PriorityCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PriorityCommand.java
@@ -32,7 +32,7 @@ public class PriorityCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         if (model.isFilteredPersonListEmpty()) {
-            return new CommandResult(String.format(Messages.MESSAGE_NO_PERSONS_FOUND, predicate.getPriorities()));
+            return new CommandResult(String.format(Messages.MESSAGE_NO_PRIORITIES_FOUND, predicate.getPriorities()));
         }
 
         return new CommandResult(


### PR DESCRIPTION
Closes #158.

Priority command uses error message of persons listing.

The message it displays is incoherent and has incorrect grammar.

Let's create a new error message for it that helps the user more.

Referring to priorities as "list of priorities" avoids plurality issues.