### PR TITLE
Fix website name

### DIFF
--- a/docs/site.json
+++ b/docs/site.json
@@ -1,6 +1,6 @@
 {
   "baseUrl": "",
-  "titlePrefix": "Organ-iser",
+  "titlePrefix": "Organ-izer",
   "titleSuffix": "",
   "faviconPath": "images/SeEduLogo.png",
   "style": {


### PR DESCRIPTION
The website name is incorrect.

This can confuse users.

Let's spell organ-izer correctly.

Follows american spelling.