### PR TITLE
Fix site name

### DIFF
--- a/docs/_markbind/layouts/default.md
+++ b/docs/_markbind/layouts/default.md
@@ -4,7 +4,7 @@
 
 <header sticky>
   <navbar type="dark">
-    <a slot="brand" href="{{baseUrl}}/index.html" title="Home" class="navbar-brand">Organ-iser</a>
+    <a slot="brand" href="{{baseUrl}}/index.html" title="Home" class="navbar-brand">Organ-izer</a>
     <li><a href="{{baseUrl}}/index.html" class="nav-link">Home</a></li>
     <li><a href="{{baseUrl}}/UserGuide.html" class="nav-link">User Guide</a></li>
     <li><a href="{{baseUrl}}/DeveloperGuide.html" class="nav-link">Developer Guide</a></li>


### PR DESCRIPTION
Website name is misspelled.

Can be confusing for users.

Let's fix it.

Should work now.